### PR TITLE
Extended config options to allow specifying the transformation scope.

### DIFF
--- a/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/bytebuddy/CompoundSource.kt
+++ b/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/bytebuddy/CompoundSource.kt
@@ -4,6 +4,7 @@ import com.google.auto.factory.AutoFactory
 import com.google.auto.factory.Provided
 import com.likethesalad.android.common.utils.bytebuddy.ByteBuddyClassesInstantiator
 import com.likethesalad.android.buddy.utils.ConcatIterator
+import com.likethesalad.android.buddy.utils.SourceElementsIterator
 import net.bytebuddy.build.Plugin
 import net.bytebuddy.dynamic.ClassFileLocator
 import java.util.jar.Manifest
@@ -11,7 +12,8 @@ import java.util.jar.Manifest
 @AutoFactory
 class CompoundSource(
     @Provided byteBuddyClassesInstantiator: ByteBuddyClassesInstantiator,
-    private val sourceOrigins: Set<Plugin.Engine.Source.Origin>
+    private val sourceOrigins: Set<Plugin.Engine.Source.Origin>,
+    private val excludePrefixes: Set<String>
 ) : Plugin.Engine.Source,
     Plugin.Engine.Source.Origin {
 
@@ -24,9 +26,9 @@ class CompoundSource(
     override fun getManifest(): Manifest? = Plugin.Engine.Source.Origin.NO_MANIFEST
 
     override fun iterator(): MutableIterator<Plugin.Engine.Source.Element> {
-        return ConcatIterator(sourceOrigins.map {
+        return SourceElementsIterator(sourceOrigins.map {
             it.iterator()
-        }.toMutableList())
+        }.toMutableList(), excludePrefixes)
     }
 
     override fun close() {

--- a/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/configuration/AndroidBuddyPluginConfiguration.kt
+++ b/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/configuration/AndroidBuddyPluginConfiguration.kt
@@ -28,7 +28,7 @@ class AndroidBuddyPluginConfiguration
     fun getTransformationScope(): MutableSet<in QualifiedContent.Scope> {
         val scope = transformationScope.scope.getOrElse(TransformationScopeType.PROJECT.name)
         return when (scope.toUpperCase()) {
-            TransformationScopeType.DEPENDENCIES.name -> mutableSetOf(QualifiedContent.Scope.PROJECT, QualifiedContent.Scope.SUB_PROJECTS, QualifiedContent.Scope.EXTERNAL_LIBRARIES)
+            TransformationScopeType.ALL.name -> mutableSetOf(QualifiedContent.Scope.PROJECT, QualifiedContent.Scope.SUB_PROJECTS, QualifiedContent.Scope.EXTERNAL_LIBRARIES)
             else -> mutableSetOf(QualifiedContent.Scope.PROJECT)
         }
     }

--- a/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/configuration/AndroidBuddyPluginConfiguration.kt
+++ b/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/configuration/AndroidBuddyPluginConfiguration.kt
@@ -1,7 +1,6 @@
 package com.likethesalad.android.buddy.configuration
 
 import com.android.build.api.transform.QualifiedContent
-import com.android.build.gradle.internal.utils.toImmutableSet
 import com.likethesalad.android.buddy.configuration.libraries.scope.LibrariesScope
 import com.likethesalad.android.buddy.configuration.libraries.scope.LibrariesScopeMapper
 import com.likethesalad.android.buddy.di.AppScope
@@ -27,8 +26,11 @@ class AndroidBuddyPluginConfiguration
     }
 
     fun getTransformationScope(): MutableSet<in QualifiedContent.Scope> {
-        val scopes = transformationScope.scope.getOrElse(mutableSetOf(QualifiedContent.Scope.PROJECT.name))
-        return scopes.map { scopeName -> QualifiedContent.Scope.valueOf(scopeName) }.toImmutableSet()
+        val scope = transformationScope.scope.getOrElse(TransformationScopeType.PROJECT.name)
+        return when (scope.toUpperCase()) {
+            TransformationScopeType.DEPENDENCIES.name -> mutableSetOf(QualifiedContent.Scope.PROJECT, QualifiedContent.Scope.SUB_PROJECTS, QualifiedContent.Scope.EXTERNAL_LIBRARIES)
+            else -> mutableSetOf(QualifiedContent.Scope.PROJECT)
+        }
     }
 
     fun getExcludePrefixes(): Set<String> {

--- a/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/configuration/AndroidBuddyPluginConfiguration.kt
+++ b/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/configuration/AndroidBuddyPluginConfiguration.kt
@@ -1,5 +1,7 @@
 package com.likethesalad.android.buddy.configuration
 
+import com.android.build.api.transform.QualifiedContent
+import com.android.build.gradle.internal.utils.toImmutableSet
 import com.likethesalad.android.buddy.configuration.libraries.scope.LibrariesScope
 import com.likethesalad.android.buddy.configuration.libraries.scope.LibrariesScopeMapper
 import com.likethesalad.android.buddy.di.AppScope
@@ -18,7 +20,18 @@ class AndroidBuddyPluginConfiguration
         librariesScopeMapper.librariesScopeExtensionToLibrariesScope(extension.librariesPolicy.scope)
     }
 
+    private val transformationScope by lazy { extension.transformationScope }
+
     fun getLibrariesScope(): LibrariesScope {
         return lazyLibrariesScope
+    }
+
+    fun getTransformationScope(): MutableSet<in QualifiedContent.Scope> {
+        val scopes = transformationScope.scope.getOrElse(mutableSetOf(QualifiedContent.Scope.PROJECT.name))
+        return scopes.map { scopeName -> QualifiedContent.Scope.valueOf(scopeName) }.toImmutableSet()
+    }
+
+    fun getExcludePrefixes(): Set<String> {
+        return transformationScope.excludePrefixes.getOrElse(emptySet())
     }
 }

--- a/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/configuration/TransformationScopeType.kt
+++ b/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/configuration/TransformationScopeType.kt
@@ -2,5 +2,5 @@ package com.likethesalad.android.buddy.configuration
 
 enum class TransformationScopeType {
     PROJECT,
-    DEPENDENCIES
+    ALL
 }

--- a/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/configuration/TransformationScopeType.kt
+++ b/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/configuration/TransformationScopeType.kt
@@ -1,0 +1,6 @@
+package com.likethesalad.android.buddy.configuration
+
+enum class TransformationScopeType {
+    PROJECT,
+    DEPENDENCIES
+}

--- a/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/extension/AndroidBuddyExtension.kt
+++ b/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/extension/AndroidBuddyExtension.kt
@@ -1,6 +1,8 @@
 package com.likethesalad.android.buddy.extension
 
+import com.android.build.api.transform.QualifiedContent
 import com.likethesalad.android.buddy.extension.libraries.LibrariesPolicyExtension
+import com.likethesalad.android.buddy.extension.libraries.TransformationScopeExtension
 import org.gradle.api.Action
 import org.gradle.api.model.ObjectFactory
 
@@ -8,8 +10,13 @@ import org.gradle.api.model.ObjectFactory
 open class AndroidBuddyExtension(objectFactory: ObjectFactory) {
 
     val librariesPolicy = objectFactory.newInstance(LibrariesPolicyExtension::class.java)
+    val transformationScope = objectFactory.newInstance(TransformationScopeExtension::class.java)
 
     fun librariesPolicy(action: Action<LibrariesPolicyExtension>) {
         action.execute(librariesPolicy)
+    }
+
+    fun transformationScope(action: Action<TransformationScopeExtension>) {
+        action.execute(transformationScope)
     }
 }

--- a/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/extension/libraries/TransformationScopeExtension.kt
+++ b/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/extension/libraries/TransformationScopeExtension.kt
@@ -1,18 +1,17 @@
 package com.likethesalad.android.buddy.extension.libraries
 
-import com.android.build.api.transform.QualifiedContent
-import com.likethesalad.android.buddy.extension.libraries.scope.LibrariesScopeExtension
-import org.gradle.api.Action
+
+import com.likethesalad.android.buddy.configuration.TransformationScopeType
 import org.gradle.api.model.ObjectFactory
 import javax.inject.Inject
 
 @Suppress("UnstableApiUsage")
 open class TransformationScopeExtension @Inject constructor(objectFactory: ObjectFactory) {
-    val scope = objectFactory.setProperty(String::class.java)
+    val scope = objectFactory.property(String::class.java)
     val excludePrefixes = objectFactory.setProperty(String::class.java)
 
     init {
-        scope.convention(mutableSetOf(QualifiedContent.Scope.PROJECT.name))
+        scope.convention(TransformationScopeType.PROJECT.name)
         excludePrefixes.convention(emptySet())
     }
 }

--- a/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/extension/libraries/TransformationScopeExtension.kt
+++ b/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/extension/libraries/TransformationScopeExtension.kt
@@ -1,0 +1,18 @@
+package com.likethesalad.android.buddy.extension.libraries
+
+import com.android.build.api.transform.QualifiedContent
+import com.likethesalad.android.buddy.extension.libraries.scope.LibrariesScopeExtension
+import org.gradle.api.Action
+import org.gradle.api.model.ObjectFactory
+import javax.inject.Inject
+
+@Suppress("UnstableApiUsage")
+open class TransformationScopeExtension @Inject constructor(objectFactory: ObjectFactory) {
+    val scope = objectFactory.setProperty(String::class.java)
+    val excludePrefixes = objectFactory.setProperty(String::class.java)
+
+    init {
+        scope.convention(mutableSetOf(QualifiedContent.Scope.PROJECT.name))
+        excludePrefixes.convention(emptySet())
+    }
+}

--- a/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/modules/transform/ByteBuddyTransform.kt
+++ b/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/modules/transform/ByteBuddyTransform.kt
@@ -3,15 +3,10 @@ package com.likethesalad.android.buddy.modules.transform
 import com.android.build.api.transform.QualifiedContent
 import com.android.build.api.transform.Transform
 import com.android.build.api.transform.TransformInvocation
-import com.likethesalad.android.buddy.bytebuddy.ClassFileLocatorMaker
-import com.likethesalad.android.buddy.bytebuddy.CompoundSource
-import com.likethesalad.android.buddy.bytebuddy.CompoundSourceFactory
-import com.likethesalad.android.buddy.bytebuddy.PluginEngineProvider
-import com.likethesalad.android.buddy.bytebuddy.SourceOriginForMultipleFoldersFactory
+import com.likethesalad.android.buddy.bytebuddy.*
 import com.likethesalad.android.buddy.configuration.AndroidBuddyPluginConfiguration
 import com.likethesalad.android.buddy.di.AppScope
 import com.likethesalad.android.buddy.modules.transform.utils.PluginFactoriesProvider
-import com.likethesalad.android.buddy.providers.LibrariesJarsProvider
 import com.likethesalad.android.buddy.providers.impl.DefaultLibrariesJarsProviderFactory
 import com.likethesalad.android.buddy.utils.ClassLoaderCreator
 import com.likethesalad.android.buddy.utils.FilesHolder
@@ -50,9 +45,7 @@ class ByteBuddyTransform @Inject constructor(
     override fun isIncremental(): Boolean = false
 
     override fun getScopes(): MutableSet<in QualifiedContent.Scope> {
-        return mutableSetOf(
-            QualifiedContent.Scope.PROJECT
-        )
+        return androidBuddyPluginConfiguration.getTransformationScope()
     }
 
     override fun getReferencedScopes(): MutableSet<in QualifiedContent.Scope> {
@@ -81,7 +74,6 @@ class ByteBuddyTransform @Inject constructor(
         val mainClassLoader = createMainClassLoader(scopeClasspath, systemClasspath)
 
         directoryCleaner.cleanDirectory(outputFolder)
-
         pluginEngineProvider.makeEngine(androidDataProvider.getJavaTargetCompatibilityVersion())
             .with(classFileLocatorMaker.make(dependencies + systemClasspath))
             .apply(
@@ -89,21 +81,28 @@ class ByteBuddyTransform @Inject constructor(
                 byteBuddyClassesInstantiator.makeTargetForFolder(outputFolder),
                 pluginFactoriesProvider.getFactories(
                     scopeClasspath.dirFiles,
-                    getLibrariesJarsProvider(dependencies),
+                    defaultLibrariesJarsProviderFactory.create(dependencies),
                     mainClassLoader
                 )
             )
     }
 
-    private fun getCompoundSource(scopeClasspath: FilesHolder): CompoundSource {
+    private fun getCompoundSource(
+        scopeClasspath: FilesHolder
+    ): CompoundSource {
+
         val origins = mutableSetOf<Plugin.Engine.Source.Origin>()
         origins.add(sourceOriginForMultipleFoldersFactory.create(scopeClasspath.dirFiles))
         for (jarFile in scopeClasspath.jarFiles) {
-            origins.add(byteBuddyClassesInstantiator.makeJarFileSourceOrigin(jarFile))
+            val origin = byteBuddyClassesInstantiator.makeJarFileSourceOrigin(jarFile)
+            if (origin.iterator().hasNext()) {
+                origins.add(origin)
+            }
         }
 
-        return compoundSourceFactory.create(origins)
+        return compoundSourceFactory.create(origins, androidBuddyPluginConfiguration.getExcludePrefixes())
     }
+
 
     private fun createMainClassLoader(
         scopeClasspath: FilesHolder,
@@ -117,9 +116,5 @@ class ByteBuddyTransform @Inject constructor(
             scopeClasspath.allFiles,
             androidClassLoader
         )
-    }
-
-    private fun getLibrariesJarsProvider(libraries: Set<File>): LibrariesJarsProvider {
-        return defaultLibrariesJarsProviderFactory.create(libraries)
     }
 }

--- a/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/utils/ConcatIterator.kt
+++ b/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/utils/ConcatIterator.kt
@@ -1,8 +1,13 @@
 package com.likethesalad.android.buddy.utils
 
-class ConcatIterator<T>(val iterators: MutableList<out Iterator<T>>) : MutableIterator<T> {
+open class ConcatIterator<T>(val iterators: MutableList<out Iterator<T>>) : MutableIterator<T> {
 
     override fun hasNext(): Boolean {
+        while (iterators.isNotEmpty() && !iterators.first().hasNext()) {
+            val first = iterators.first()
+            iterators.remove(first)
+        }
+
         if (iterators.isEmpty()) {
             return false
         }

--- a/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/utils/SourceElementsIterator.kt
+++ b/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/utils/SourceElementsIterator.kt
@@ -1,18 +1,18 @@
 package com.likethesalad.android.buddy.utils
 
 import net.bytebuddy.build.Plugin
-import javax.net.ssl.HttpsURLConnection
-import kotlin.jvm.javaClass
 
-class ElementsIterator(iterators: MutableList<out Iterator<Plugin.Engine.Source.Element>>) : ConcatIterator<Plugin.Engine.Source.Element>(iterators) {
-    var nextElement: Plugin.Engine.Source.Element? = null
+class SourceElementsIterator(
+    iterators: MutableList<out Iterator<Plugin.Engine.Source.Element>>,
+    private val excludePrefixes: Set<String>
+) : ConcatIterator<Plugin.Engine.Source.Element>(iterators) {
+    private var nextElement: Plugin.Engine.Source.Element? = null
 
     override fun hasNext(): Boolean {
         if (nextElement == null) {
-            var element: Plugin.Engine.Source.Element?
             while (super.hasNext()) {
-                element = super.next()
-                if (!element.name.startsWith("META-INF")) {
+                val element = super.next()
+                if (excludePrefixes.isEmpty() || excludePrefixes.none { element.name.startsWith(it) }) {
                     nextElement = element
                     return true
                 }
@@ -28,17 +28,8 @@ class ElementsIterator(iterators: MutableList<out Iterator<Plugin.Engine.Source.
         hasNext()
 
         val tmp = nextElement
-
-
-        return tmp ?: -1
-        if(tmp != null){
-            return tmp
-        } else {
-
-        }
-         as T
         nextElement = null
-        return tmp
+        return tmp ?: throw IllegalStateException("no next source element available")
     }
 
     override fun remove() {

--- a/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/utils/SourceElementsIterator.kt
+++ b/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/utils/SourceElementsIterator.kt
@@ -1,0 +1,47 @@
+package com.likethesalad.android.buddy.utils
+
+import net.bytebuddy.build.Plugin
+import javax.net.ssl.HttpsURLConnection
+import kotlin.jvm.javaClass
+
+class ElementsIterator(iterators: MutableList<out Iterator<Plugin.Engine.Source.Element>>) : ConcatIterator<Plugin.Engine.Source.Element>(iterators) {
+    var nextElement: Plugin.Engine.Source.Element? = null
+
+    override fun hasNext(): Boolean {
+        if (nextElement == null) {
+            var element: Plugin.Engine.Source.Element?
+            while (super.hasNext()) {
+                element = super.next()
+                if (!element.name.startsWith("META-INF")) {
+                    nextElement = element
+                    return true
+                }
+            }
+
+            return false
+        } else {
+            return true
+        }
+    }
+
+    override fun next(): Plugin.Engine.Source.Element {
+        hasNext()
+
+        val tmp = nextElement
+
+
+        return tmp ?: -1
+        if(tmp != null){
+            return tmp
+        } else {
+
+        }
+         as T
+        nextElement = null
+        return tmp
+    }
+
+    override fun remove() {
+        throw UnsupportedOperationException()
+    }
+}

--- a/android-buddy-plugin/src/test/java/com/likethesalad/android/buddy/bytebuddy/CompoundSourceTest.kt
+++ b/android-buddy-plugin/src/test/java/com/likethesalad/android/buddy/bytebuddy/CompoundSourceTest.kt
@@ -30,7 +30,7 @@ class CompoundSourceTest : BaseMockable() {
     @Before
     fun setUp() {
         origins = setOf(origin1, origin2)
-        compoundSource = CompoundSource(byteBuddyClassesInstantiator, origins)
+        compoundSource = CompoundSource(byteBuddyClassesInstantiator, origins, emptySet())
     }
 
     @Test


### PR DESCRIPTION
Previously only project classes where considered for transformation. This PR allows to specify the transformation scope in the configuration and in addition allows to exclude certain classes / resources by prefixes:

```
...
androidBuddy {
    transformationScope {
        scope = [
                'PROJECT',
                'SUB_PROJECTS',
                'EXTERNAL_LIBRARIES'
        ]
        excludePrefixes = [
                'META-INF/android-buddy-plugins'
        ]
    }
}
...
```