### PR TITLE
Release/1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Change Log
+## [1.1.1] - 2021-06-30
+### Fixed
+- Saving classes that were skipped from transformation into the final runtime classpath.
 ## [1.1.0] - 2021-06-28
 ### Added
 - Changelog file

--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ doing so, while still accomplishing your goals, by following the suggestions bel
 - If you want to transform a library class that you don't extend from, such as the "android.util.Log" one, you
   should consider instead wrapping said class within your own class and then add there all the code you need, maybe without
   having to transform it. This is a good practice that will prevent you from spreading a foreign class across your 
-  project which will in turn give you more power to replace the library you're using in te future if needed (not the 
+  project which will in turn give you more power to replace the library you're using in the future if needed (not the 
   Android SDK one but any other third party lib) and/or to be able of quickly adapt your project to any of said library's
   breaking changes, if any, in future releases.
   

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Whether you're planning to set up a producer or consumer project, or both, you'd
 As a first step for both producers and consumers, you'd have to add Android Buddy as a Gradle plugin of your Android project by adding the following line into your `root` `build.gradle`'s buildscript' dependencies:
 
 ```groovy
-classpath "com.likethesalad.android:android-buddy-plugin:1.1.0"
+classpath "com.likethesalad.android:android-buddy-plugin:1.1.1"
 ```
 
 **Example**
@@ -239,7 +239,7 @@ buildscript {
 
   dependencies {
     classpath 'com.android.tools.build:gradle:3.5.+' // Requires Android build plugin version 3.5.4 or higher.
-    classpath "com.likethesalad.android:android-buddy-plugin:1.1.0"
+    classpath "com.likethesalad.android:android-buddy-plugin:1.1.1"
   }
 }
 ```

--- a/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/bytebuddy/CompoundSource.kt
+++ b/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/bytebuddy/CompoundSource.kt
@@ -3,6 +3,7 @@ package com.likethesalad.android.buddy.bytebuddy
 import com.google.auto.factory.AutoFactory
 import com.google.auto.factory.Provided
 import com.likethesalad.android.buddy.modules.transform.utils.bytebuddy.SourceElementTransformationSkipPolicy
+import com.likethesalad.android.buddy.modules.transform.utils.bytebuddy.SourceElementTransformationSkippedStrategy
 import com.likethesalad.android.buddy.utils.SourceElementsIterator
 import com.likethesalad.android.common.utils.bytebuddy.ByteBuddyClassesInstantiator
 import net.bytebuddy.build.Plugin
@@ -13,7 +14,8 @@ import java.util.jar.Manifest
 class CompoundSource(
     @Provided byteBuddyClassesInstantiator: ByteBuddyClassesInstantiator,
     private val sourceOrigins: Set<Plugin.Engine.Source.Origin>,
-    private val skipPolicy: SourceElementTransformationSkipPolicy
+    private val skipPolicy: SourceElementTransformationSkipPolicy,
+    private val skippedStrategy: SourceElementTransformationSkippedStrategy
 ) : Plugin.Engine.Source,
     Plugin.Engine.Source.Origin {
 
@@ -28,7 +30,7 @@ class CompoundSource(
     override fun iterator(): MutableIterator<Plugin.Engine.Source.Element> {
         return SourceElementsIterator(sourceOrigins.map {
             it.iterator()
-        }.toMutableList(), skipPolicy)
+        }.toMutableList(), skipPolicy, skippedStrategy)
     }
 
     override fun close() {

--- a/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/bytebuddy/CompoundSource.kt
+++ b/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/bytebuddy/CompoundSource.kt
@@ -2,9 +2,9 @@ package com.likethesalad.android.buddy.bytebuddy
 
 import com.google.auto.factory.AutoFactory
 import com.google.auto.factory.Provided
-import com.likethesalad.android.common.utils.bytebuddy.ByteBuddyClassesInstantiator
-import com.likethesalad.android.buddy.utils.ConcatIterator
+import com.likethesalad.android.buddy.modules.transform.utils.bytebuddy.SourceElementTransformationSkipPolicy
 import com.likethesalad.android.buddy.utils.SourceElementsIterator
+import com.likethesalad.android.common.utils.bytebuddy.ByteBuddyClassesInstantiator
 import net.bytebuddy.build.Plugin
 import net.bytebuddy.dynamic.ClassFileLocator
 import java.util.jar.Manifest
@@ -13,7 +13,7 @@ import java.util.jar.Manifest
 class CompoundSource(
     @Provided byteBuddyClassesInstantiator: ByteBuddyClassesInstantiator,
     private val sourceOrigins: Set<Plugin.Engine.Source.Origin>,
-    private val excludePrefixes: Set<String>
+    private val skipPolicy: SourceElementTransformationSkipPolicy
 ) : Plugin.Engine.Source,
     Plugin.Engine.Source.Origin {
 
@@ -28,7 +28,7 @@ class CompoundSource(
     override fun iterator(): MutableIterator<Plugin.Engine.Source.Element> {
         return SourceElementsIterator(sourceOrigins.map {
             it.iterator()
-        }.toMutableList(), excludePrefixes)
+        }.toMutableList(), skipPolicy)
     }
 
     override fun close() {

--- a/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/configuration/AndroidBuddyPluginConfiguration.kt
+++ b/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/configuration/AndroidBuddyPluginConfiguration.kt
@@ -18,22 +18,30 @@ class AndroidBuddyPluginConfiguration
     private val lazyLibrariesScope: LibrariesScope by lazy {
         librariesScopeMapper.librariesScopeExtensionToLibrariesScope(extension.librariesPolicy.scope)
     }
-
-    private val transformationScope by lazy { extension.transformationScope }
+    private val lazyTransformationScope: MutableSet<in QualifiedContent.Scope> by lazy {
+        val scope = extension.transformationScope.scope.getOrElse(TransformationScopeType.PROJECT.name)
+        when (scope.toUpperCase()) {
+            TransformationScopeType.ALL.name -> mutableSetOf(
+                QualifiedContent.Scope.PROJECT,
+                QualifiedContent.Scope.SUB_PROJECTS,
+                QualifiedContent.Scope.EXTERNAL_LIBRARIES
+            )
+            else -> mutableSetOf(QualifiedContent.Scope.PROJECT)
+        }
+    }
+    private val lazyExcludePrefixes: Set<String> by lazy {
+        extension.transformationScope.excludePrefixes.getOrElse(emptySet())
+    }
 
     fun getLibrariesScope(): LibrariesScope {
         return lazyLibrariesScope
     }
 
     fun getTransformationScope(): MutableSet<in QualifiedContent.Scope> {
-        val scope = transformationScope.scope.getOrElse(TransformationScopeType.PROJECT.name)
-        return when (scope.toUpperCase()) {
-            TransformationScopeType.ALL.name -> mutableSetOf(QualifiedContent.Scope.PROJECT, QualifiedContent.Scope.SUB_PROJECTS, QualifiedContent.Scope.EXTERNAL_LIBRARIES)
-            else -> mutableSetOf(QualifiedContent.Scope.PROJECT)
-        }
+        return lazyTransformationScope
     }
 
     fun getExcludePrefixes(): Set<String> {
-        return transformationScope.excludePrefixes.getOrElse(emptySet())
+        return lazyExcludePrefixes
     }
 }

--- a/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/extension/AndroidBuddyExtension.kt
+++ b/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/extension/AndroidBuddyExtension.kt
@@ -1,6 +1,5 @@
 package com.likethesalad.android.buddy.extension
 
-import com.android.build.api.transform.QualifiedContent
 import com.likethesalad.android.buddy.extension.libraries.LibrariesPolicyExtension
 import com.likethesalad.android.buddy.extension.libraries.TransformationScopeExtension
 import org.gradle.api.Action

--- a/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/modules/transform/ByteBuddyTransform.kt
+++ b/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/modules/transform/ByteBuddyTransform.kt
@@ -11,6 +11,7 @@ import com.likethesalad.android.buddy.bytebuddy.SourceOriginForMultipleFoldersFa
 import com.likethesalad.android.buddy.configuration.AndroidBuddyPluginConfiguration
 import com.likethesalad.android.buddy.di.AppScope
 import com.likethesalad.android.buddy.modules.transform.utils.PluginFactoriesProvider
+import com.likethesalad.android.buddy.modules.transform.utils.bytebuddy.SourceElementTransformationSkipPolicyFactory
 import com.likethesalad.android.buddy.providers.impl.DefaultLibrariesJarsProviderFactory
 import com.likethesalad.android.buddy.utils.ClassLoaderCreator
 import com.likethesalad.android.buddy.utils.FilesHolder
@@ -37,7 +38,8 @@ class ByteBuddyTransform @Inject constructor(
     private val androidVariantDataProviderFactory: AndroidVariantDataProviderFactory,
     private val androidExtensionDataProvider: AndroidExtensionDataProvider,
     private val defaultLibrariesJarsProviderFactory: DefaultLibrariesJarsProviderFactory,
-    private val androidBuddyPluginConfiguration: AndroidBuddyPluginConfiguration
+    private val androidBuddyPluginConfiguration: AndroidBuddyPluginConfiguration,
+    private val sourceElementTransformationSkipPolicyFactory: SourceElementTransformationSkipPolicyFactory
 ) : Transform() {
 
     override fun getName(): String = "androidBuddy"
@@ -93,9 +95,7 @@ class ByteBuddyTransform @Inject constructor(
             )
     }
 
-    private fun getCompoundSource(
-        scopeClasspath: FilesHolder
-    ): CompoundSource {
+    private fun getCompoundSource(scopeClasspath: FilesHolder): CompoundSource {
 
         val origins = mutableSetOf<Plugin.Engine.Source.Origin>()
         origins.add(sourceOriginForMultipleFoldersFactory.create(scopeClasspath.dirFiles))
@@ -106,7 +106,10 @@ class ByteBuddyTransform @Inject constructor(
             }
         }
 
-        return compoundSourceFactory.create(origins, androidBuddyPluginConfiguration.getExcludePrefixes())
+        return compoundSourceFactory.create(
+            origins,
+            sourceElementTransformationSkipPolicyFactory.create(androidBuddyPluginConfiguration.getExcludePrefixes())
+        )
     }
 
 

--- a/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/modules/transform/ByteBuddyTransform.kt
+++ b/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/modules/transform/ByteBuddyTransform.kt
@@ -3,7 +3,11 @@ package com.likethesalad.android.buddy.modules.transform
 import com.android.build.api.transform.QualifiedContent
 import com.android.build.api.transform.Transform
 import com.android.build.api.transform.TransformInvocation
-import com.likethesalad.android.buddy.bytebuddy.*
+import com.likethesalad.android.buddy.bytebuddy.ClassFileLocatorMaker
+import com.likethesalad.android.buddy.bytebuddy.CompoundSource
+import com.likethesalad.android.buddy.bytebuddy.CompoundSourceFactory
+import com.likethesalad.android.buddy.bytebuddy.PluginEngineProvider
+import com.likethesalad.android.buddy.bytebuddy.SourceOriginForMultipleFoldersFactory
 import com.likethesalad.android.buddy.configuration.AndroidBuddyPluginConfiguration
 import com.likethesalad.android.buddy.di.AppScope
 import com.likethesalad.android.buddy.modules.transform.utils.PluginFactoriesProvider
@@ -57,7 +61,9 @@ class ByteBuddyTransform @Inject constructor(
 
     override fun getParameterInputs(): MutableMap<String, Any> {
         return mutableMapOf(
-            "librariesScopeHash" to androidBuddyPluginConfiguration.getLibrariesScope().hashCode()
+            "librariesScopeHash" to androidBuddyPluginConfiguration.getLibrariesScope().hashCode(),
+            "transformationScopeHash" to androidBuddyPluginConfiguration.getTransformationScope().hashCode(),
+            "excludePrefixesScopeHash" to androidBuddyPluginConfiguration.getExcludePrefixes().hashCode()
         )
     }
 

--- a/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/modules/transform/ByteBuddyTransform.kt
+++ b/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/modules/transform/ByteBuddyTransform.kt
@@ -12,6 +12,7 @@ import com.likethesalad.android.buddy.configuration.AndroidBuddyPluginConfigurat
 import com.likethesalad.android.buddy.di.AppScope
 import com.likethesalad.android.buddy.modules.transform.utils.PluginFactoriesProvider
 import com.likethesalad.android.buddy.modules.transform.utils.bytebuddy.SourceElementTransformationSkipPolicyFactory
+import com.likethesalad.android.buddy.modules.transform.utils.bytebuddy.SourceElementTransformationSkippedStrategyFactory
 import com.likethesalad.android.buddy.providers.impl.DefaultLibrariesJarsProviderFactory
 import com.likethesalad.android.buddy.utils.ClassLoaderCreator
 import com.likethesalad.android.buddy.utils.FilesHolder
@@ -39,7 +40,8 @@ class ByteBuddyTransform @Inject constructor(
     private val androidExtensionDataProvider: AndroidExtensionDataProvider,
     private val defaultLibrariesJarsProviderFactory: DefaultLibrariesJarsProviderFactory,
     private val androidBuddyPluginConfiguration: AndroidBuddyPluginConfiguration,
-    private val sourceElementTransformationSkipPolicyFactory: SourceElementTransformationSkipPolicyFactory
+    private val sourceElementTransformationSkipPolicyFactory: SourceElementTransformationSkipPolicyFactory,
+    private val sourceElementTransformationSkippedStrategyFactory: SourceElementTransformationSkippedStrategyFactory
 ) : Transform() {
 
     override fun getName(): String = "androidBuddy"
@@ -85,7 +87,7 @@ class ByteBuddyTransform @Inject constructor(
         pluginEngineProvider.makeEngine(androidDataProvider.getJavaTargetCompatibilityVersion())
             .with(classFileLocatorMaker.make(dependencies + systemClasspath))
             .apply(
-                getCompoundSource(scopeClasspath),
+                getCompoundSource(scopeClasspath, outputFolder),
                 byteBuddyClassesInstantiator.makeTargetForFolder(outputFolder),
                 pluginFactoriesProvider.getFactories(
                     scopeClasspath.dirFiles,
@@ -95,7 +97,7 @@ class ByteBuddyTransform @Inject constructor(
             )
     }
 
-    private fun getCompoundSource(scopeClasspath: FilesHolder): CompoundSource {
+    private fun getCompoundSource(scopeClasspath: FilesHolder, outputFolder: File): CompoundSource {
 
         val origins = mutableSetOf<Plugin.Engine.Source.Origin>()
         origins.add(sourceOriginForMultipleFoldersFactory.create(scopeClasspath.dirFiles))
@@ -108,7 +110,8 @@ class ByteBuddyTransform @Inject constructor(
 
         return compoundSourceFactory.create(
             origins,
-            sourceElementTransformationSkipPolicyFactory.create(androidBuddyPluginConfiguration.getExcludePrefixes())
+            sourceElementTransformationSkipPolicyFactory.create(androidBuddyPluginConfiguration.getExcludePrefixes()),
+            sourceElementTransformationSkippedStrategyFactory.create(outputFolder)
         )
     }
 

--- a/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/modules/transform/base/TransformationSkipPolicy.kt
+++ b/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/modules/transform/base/TransformationSkipPolicy.kt
@@ -1,0 +1,5 @@
+package com.likethesalad.android.buddy.modules.transform.base
+
+interface TransformationSkipPolicy<T : Any> {
+    fun shouldSkipItem(item: T): Boolean
+}

--- a/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/modules/transform/base/TransformationSkippedStrategy.kt
+++ b/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/modules/transform/base/TransformationSkippedStrategy.kt
@@ -1,0 +1,5 @@
+package com.likethesalad.android.buddy.modules.transform.base
+
+interface TransformationSkippedStrategy<T : Any> {
+    fun onTransformationSkipped(item: T)
+}

--- a/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/modules/transform/utils/FilePathScanner.kt
+++ b/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/modules/transform/utils/FilePathScanner.kt
@@ -1,10 +1,10 @@
 package com.likethesalad.android.buddy.modules.transform.utils
 
+import com.likethesalad.android.buddy.di.AppScope
 import java.io.File
 import javax.inject.Inject
-import javax.inject.Singleton
 
-@Singleton
+@AppScope
 class FilePathScanner @Inject constructor() {
 
     fun scanFilePath(path: String): FileInfo {

--- a/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/modules/transform/utils/FilePathScanner.kt
+++ b/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/modules/transform/utils/FilePathScanner.kt
@@ -1,0 +1,16 @@
+package com.likethesalad.android.buddy.modules.transform.utils
+
+import java.io.File
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class FilePathScanner @Inject constructor() {
+
+    fun scanFilePath(path: String): FileInfo {
+        val file = File(path)
+        return FileInfo(file.name, file.parent)
+    }
+
+    data class FileInfo(val name: String, val dirPath: String)
+}

--- a/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/modules/transform/utils/bytebuddy/SourceElementTransformationSkipPolicy.kt
+++ b/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/modules/transform/utils/bytebuddy/SourceElementTransformationSkipPolicy.kt
@@ -1,0 +1,17 @@
+package com.likethesalad.android.buddy.modules.transform.utils.bytebuddy
+
+import com.google.auto.factory.AutoFactory
+import com.likethesalad.android.buddy.modules.transform.base.TransformationSkipPolicy
+import net.bytebuddy.build.Plugin
+import javax.inject.Inject
+
+@AutoFactory
+class SourceElementTransformationSkipPolicy
+@Inject constructor(private val excludePrefixes: Set<String>) : TransformationSkipPolicy<Plugin.Engine.Source.Element> {
+
+    override fun shouldSkipItem(item: Plugin.Engine.Source.Element): Boolean {
+        return excludePrefixes.any { prefix ->
+            item.name.startsWith(prefix)
+        }
+    }
+}

--- a/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/modules/transform/utils/bytebuddy/SourceElementTransformationSkippedStrategy.kt
+++ b/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/modules/transform/utils/bytebuddy/SourceElementTransformationSkippedStrategy.kt
@@ -1,0 +1,28 @@
+package com.likethesalad.android.buddy.modules.transform.utils.bytebuddy
+
+import com.google.auto.factory.AutoFactory
+import com.google.auto.factory.Provided
+import com.likethesalad.android.buddy.modules.transform.base.TransformationSkippedStrategy
+import com.likethesalad.android.buddy.modules.transform.utils.FilePathScanner
+import net.bytebuddy.build.Plugin
+import java.io.File
+
+@AutoFactory
+class SourceElementTransformationSkippedStrategy(
+    private val outputDir: File,
+    @Provided private val filePathScanner: FilePathScanner
+) : TransformationSkippedStrategy<Plugin.Engine.Source.Element> {
+
+    override fun onTransformationSkipped(item: Plugin.Engine.Source.Element) {
+        val fileInfo = filePathScanner.scanFilePath(item.name)
+        val outputFileDir = File(outputDir, fileInfo.dirPath)
+
+        if (!outputFileDir.exists()) {
+            outputFileDir.mkdirs()
+        }
+
+        File(outputFileDir, fileInfo.name).outputStream().use { outputStream ->
+            item.inputStream.copyTo(outputStream)
+        }
+    }
+}

--- a/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/modules/transform/utils/bytebuddy/SourceElementTransformationSkippedStrategy.kt
+++ b/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/modules/transform/utils/bytebuddy/SourceElementTransformationSkippedStrategy.kt
@@ -4,16 +4,24 @@ import com.google.auto.factory.AutoFactory
 import com.google.auto.factory.Provided
 import com.likethesalad.android.buddy.modules.transform.base.TransformationSkippedStrategy
 import com.likethesalad.android.buddy.modules.transform.utils.FilePathScanner
+import com.likethesalad.android.common.utils.Logger
 import net.bytebuddy.build.Plugin
 import java.io.File
 
 @AutoFactory
 class SourceElementTransformationSkippedStrategy(
     private val outputDir: File,
-    @Provided private val filePathScanner: FilePathScanner
+    @Provided private val filePathScanner: FilePathScanner,
+    @Provided private val logger: Logger
 ) : TransformationSkippedStrategy<Plugin.Engine.Source.Element> {
 
     override fun onTransformationSkipped(item: Plugin.Engine.Source.Element) {
+        if (item.inputStream.available() == 0) {
+            logger.debug("Skipping to save item: {}, it's probably a folder", item.name)
+            return
+        }
+        logger.debug("Attempting to save item: {}", item.name)
+
         val fileInfo = filePathScanner.scanFilePath(item.name)
         val outputFileDir = File(outputDir, fileInfo.dirPath)
 

--- a/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/utils/SourceElementsIterator.kt
+++ b/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/utils/SourceElementsIterator.kt
@@ -1,10 +1,11 @@
 package com.likethesalad.android.buddy.utils
 
+import com.likethesalad.android.buddy.modules.transform.utils.bytebuddy.SourceElementTransformationSkipPolicy
 import net.bytebuddy.build.Plugin
 
 class SourceElementsIterator(
     iterators: MutableList<out Iterator<Plugin.Engine.Source.Element>>,
-    private val excludePrefixes: Set<String>
+    private val skipPolicy: SourceElementTransformationSkipPolicy
 ) : ConcatIterator<Plugin.Engine.Source.Element>(iterators) {
     private var nextElement: Plugin.Engine.Source.Element? = null
 
@@ -12,7 +13,7 @@ class SourceElementsIterator(
         if (nextElement == null) {
             while (super.hasNext()) {
                 val element = super.next()
-                if (excludePrefixes.isEmpty() || excludePrefixes.none { element.name.startsWith(it) }) {
+                if (!skipPolicy.shouldSkipItem(element)) {
                     nextElement = element
                     return true
                 }

--- a/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/utils/SourceElementsIterator.kt
+++ b/android-buddy-plugin/src/main/java/com/likethesalad/android/buddy/utils/SourceElementsIterator.kt
@@ -1,11 +1,13 @@
 package com.likethesalad.android.buddy.utils
 
 import com.likethesalad.android.buddy.modules.transform.utils.bytebuddy.SourceElementTransformationSkipPolicy
+import com.likethesalad.android.buddy.modules.transform.utils.bytebuddy.SourceElementTransformationSkippedStrategy
 import net.bytebuddy.build.Plugin
 
 class SourceElementsIterator(
     iterators: MutableList<out Iterator<Plugin.Engine.Source.Element>>,
-    private val skipPolicy: SourceElementTransformationSkipPolicy
+    private val skipPolicy: SourceElementTransformationSkipPolicy,
+    private val skippedStrategy: SourceElementTransformationSkippedStrategy
 ) : ConcatIterator<Plugin.Engine.Source.Element>(iterators) {
     private var nextElement: Plugin.Engine.Source.Element? = null
 
@@ -16,6 +18,8 @@ class SourceElementsIterator(
                 if (!skipPolicy.shouldSkipItem(element)) {
                     nextElement = element
                     return true
+                } else {
+                    skippedStrategy.onTransformationSkipped(element)
                 }
             }
 

--- a/android-buddy-plugin/src/test/java/com/likethesalad/android/buddy/bytebuddy/CompoundSourceTest.kt
+++ b/android-buddy-plugin/src/test/java/com/likethesalad/android/buddy/bytebuddy/CompoundSourceTest.kt
@@ -1,8 +1,9 @@
 package com.likethesalad.android.buddy.bytebuddy
 
 import com.google.common.truth.Truth
-import com.likethesalad.android.common.utils.bytebuddy.ByteBuddyClassesInstantiator
+import com.likethesalad.android.buddy.modules.transform.utils.bytebuddy.SourceElementTransformationSkipPolicy
 import com.likethesalad.android.buddy.utils.ConcatIterator
+import com.likethesalad.android.common.utils.bytebuddy.ByteBuddyClassesInstantiator
 import com.likethesalad.android.testutils.BaseMockable
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
@@ -23,6 +24,9 @@ class CompoundSourceTest : BaseMockable() {
     @MockK
     lateinit var origin2: Plugin.Engine.Source.Origin
 
+    @MockK
+    lateinit var sourceElementTransformationSkipPolicy: SourceElementTransformationSkipPolicy
+
     private lateinit var origins: Set<Plugin.Engine.Source.Origin>
 
     private lateinit var compoundSource: CompoundSource
@@ -30,7 +34,7 @@ class CompoundSourceTest : BaseMockable() {
     @Before
     fun setUp() {
         origins = setOf(origin1, origin2)
-        compoundSource = CompoundSource(byteBuddyClassesInstantiator, origins, emptySet())
+        compoundSource = CompoundSource(byteBuddyClassesInstantiator, origins, sourceElementTransformationSkipPolicy)
     }
 
     @Test

--- a/android-buddy-plugin/src/test/java/com/likethesalad/android/buddy/bytebuddy/CompoundSourceTest.kt
+++ b/android-buddy-plugin/src/test/java/com/likethesalad/android/buddy/bytebuddy/CompoundSourceTest.kt
@@ -2,6 +2,7 @@ package com.likethesalad.android.buddy.bytebuddy
 
 import com.google.common.truth.Truth
 import com.likethesalad.android.buddy.modules.transform.utils.bytebuddy.SourceElementTransformationSkipPolicy
+import com.likethesalad.android.buddy.modules.transform.utils.bytebuddy.SourceElementTransformationSkippedStrategy
 import com.likethesalad.android.buddy.utils.ConcatIterator
 import com.likethesalad.android.common.utils.bytebuddy.ByteBuddyClassesInstantiator
 import com.likethesalad.android.testutils.BaseMockable
@@ -27,6 +28,9 @@ class CompoundSourceTest : BaseMockable() {
     @MockK
     lateinit var sourceElementTransformationSkipPolicy: SourceElementTransformationSkipPolicy
 
+    @MockK
+    lateinit var sourceElementTransformationSkippedStrategy: SourceElementTransformationSkippedStrategy
+
     private lateinit var origins: Set<Plugin.Engine.Source.Origin>
 
     private lateinit var compoundSource: CompoundSource
@@ -34,7 +38,12 @@ class CompoundSourceTest : BaseMockable() {
     @Before
     fun setUp() {
         origins = setOf(origin1, origin2)
-        compoundSource = CompoundSource(byteBuddyClassesInstantiator, origins, sourceElementTransformationSkipPolicy)
+        compoundSource = CompoundSource(
+            byteBuddyClassesInstantiator,
+            origins,
+            sourceElementTransformationSkipPolicy,
+            sourceElementTransformationSkippedStrategy
+        )
     }
 
     @Test

--- a/android-buddy-plugin/src/test/java/com/likethesalad/android/buddy/configuration/AndroidBuddyPluginConfigurationTest.kt
+++ b/android-buddy-plugin/src/test/java/com/likethesalad/android/buddy/configuration/AndroidBuddyPluginConfigurationTest.kt
@@ -1,0 +1,130 @@
+package com.likethesalad.android.buddy.configuration
+
+import com.android.build.api.transform.QualifiedContent
+import com.google.common.truth.Truth
+import com.likethesalad.android.buddy.configuration.libraries.scope.LibrariesScope
+import com.likethesalad.android.buddy.configuration.libraries.scope.LibrariesScopeMapper
+import com.likethesalad.android.buddy.extension.AndroidBuddyExtension
+import com.likethesalad.android.buddy.extension.libraries.LibrariesPolicyExtension
+import com.likethesalad.android.buddy.extension.libraries.TransformationScopeExtension
+import com.likethesalad.android.buddy.extension.libraries.scope.LibrariesScopeExtension
+import com.likethesalad.android.buddy.providers.AndroidBuddyExtensionProvider
+import com.likethesalad.android.testutils.BaseMockable
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.SetProperty
+import org.junit.Before
+import org.junit.Test
+
+@Suppress("UnstableApiUsage")
+class AndroidBuddyPluginConfigurationTest : BaseMockable() {
+
+    @MockK
+    lateinit var androidBuddyExtensionProvider: AndroidBuddyExtensionProvider
+
+    @MockK
+    lateinit var librariesScopeMapper: LibrariesScopeMapper
+
+    @MockK
+    lateinit var extension: AndroidBuddyExtension
+
+    @MockK
+    lateinit var librariesPolicyExtension: LibrariesPolicyExtension
+
+    @MockK
+    lateinit var librariesScopeExtension: LibrariesScopeExtension
+
+    @MockK
+    lateinit var transformationScopeExtension: TransformationScopeExtension
+
+    private lateinit var androidBuddyPluginConfiguration: AndroidBuddyPluginConfiguration
+
+    @Before
+    fun setUp() {
+        every {
+            androidBuddyExtensionProvider.getAndroidBuddyExtension()
+        }.returns(extension)
+        every {
+            extension.librariesPolicy
+        }.returns(librariesPolicyExtension)
+        every {
+            librariesPolicyExtension.scope
+        }.returns(librariesScopeExtension)
+        every {
+            extension.transformationScope
+        }.returns(transformationScopeExtension)
+
+        androidBuddyPluginConfiguration =
+            AndroidBuddyPluginConfiguration(androidBuddyExtensionProvider, librariesScopeMapper)
+    }
+
+    @Test
+    fun `Get libraries scope`() {
+        val expected = LibrariesScope.UseAll
+        every {
+            librariesScopeMapper.librariesScopeExtensionToLibrariesScope(librariesScopeExtension)
+        }.returns(expected)
+
+        val result = androidBuddyPluginConfiguration.getLibrariesScope()
+
+        Truth.assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun `Get PROJECT transformation scope`() {
+        val scopeExtension = "PROJECT"
+        val scopeProperty = createPropertyOf(scopeExtension)
+        every {
+            transformationScopeExtension.scope
+        }.returns(scopeProperty)
+
+        val result = androidBuddyPluginConfiguration.getTransformationScope()
+
+        Truth.assertThat(result).containsExactly(QualifiedContent.Scope.PROJECT)
+    }
+
+    @Test
+    fun `Get ALL transformation scope`() {
+        val scopeExtension = "ALL"
+        val scopeProperty = createPropertyOf(scopeExtension)
+        every {
+            transformationScopeExtension.scope
+        }.returns(scopeProperty)
+
+        val result = androidBuddyPluginConfiguration.getTransformationScope()
+
+        Truth.assertThat(result).containsExactly(
+            QualifiedContent.Scope.PROJECT,
+            QualifiedContent.Scope.EXTERNAL_LIBRARIES,
+            QualifiedContent.Scope.SUB_PROJECTS
+        )
+    }
+
+    @Test
+    fun `Get excluded prefixes`() {
+        val property = createSetPropertyOf("one/prefix", "second/prefix/another")
+        every { transformationScopeExtension.excludePrefixes }.returns(property)
+
+        val result = androidBuddyPluginConfiguration.getExcludePrefixes()
+
+        Truth.assertThat(result).containsExactly("one/prefix", "second/prefix/another")
+    }
+
+    private inline fun <reified T : Any> createPropertyOf(value: T): Property<T> {
+        val mock = mockk<Property<T>>()
+        every { mock.get() }.returns(value)
+        every { mock.getOrElse(any()) }.returns(value)
+
+        return mock
+    }
+
+    private inline fun <reified T : Any> createSetPropertyOf(vararg values: T): SetProperty<T> {
+        val mock = mockk<SetProperty<T>>()
+        val setValues = values.toSet()
+        every { mock.get() }.returns(setValues)
+        every { mock.getOrElse(any()) }.returns(setValues)
+
+        return mock
+    }
+}

--- a/android-buddy-plugin/src/test/java/com/likethesalad/android/buddy/modules/transform/ByteBuddyTransformTest.kt
+++ b/android-buddy-plugin/src/test/java/com/likethesalad/android/buddy/modules/transform/ByteBuddyTransformTest.kt
@@ -106,11 +106,13 @@ class ByteBuddyTransformTest : BaseMockable() {
         every { androidExtensionDataProvider.getBootClasspath() }.returns(androidBoothClasspath)
         every { androidVariantDataProvider.getJavaTargetCompatibilityVersion() }.returns(javaTargetVersion)
         every { pluginEngineProvider.makeEngine(javaTargetVersion) }.returns(pluginEngine)
-        every { androidBuddyPluginConfiguration.getTransformationScope() }.returns(mutableSetOf(
-            QualifiedContent.Scope.PROJECT,
-            QualifiedContent.Scope.SUB_PROJECTS,
-            QualifiedContent.Scope.EXTERNAL_LIBRARIES
-        ))
+        every { androidBuddyPluginConfiguration.getTransformationScope() }.returns(
+            mutableSetOf(
+                QualifiedContent.Scope.PROJECT,
+                QualifiedContent.Scope.SUB_PROJECTS,
+                QualifiedContent.Scope.EXTERNAL_LIBRARIES
+            )
+        )
         every { androidBuddyPluginConfiguration.getExcludePrefixes() }.returns(emptySet())
         byteBuddyTransform = ByteBuddyTransform(
             classFileLocatorMaker,
@@ -161,13 +163,25 @@ class ByteBuddyTransformTest : BaseMockable() {
     @Test
     fun `Get map with config hashes`() {
         val librariesScope = mockk<LibrariesScope>()
-        val hash = 1
-        every { librariesScope.hashCode() }.returns(hash)
+        val transformationScope = mockk<MutableSet<in QualifiedContent.Scope>>()
+        val excludePrefixes = mockk<Set<String>>()
+        val librariesScopeHash = 1
+        val transformationScopeHash = 2
+        val excludePrefixesHash = 3
+        every { librariesScope.hashCode() }.returns(librariesScopeHash)
+        every { transformationScope.hashCode() }.returns(transformationScopeHash)
+        every { excludePrefixes.hashCode() }.returns(excludePrefixesHash)
         every { androidBuddyPluginConfiguration.getLibrariesScope() }.returns(librariesScope)
+        every { androidBuddyPluginConfiguration.getTransformationScope() }.returns(transformationScope)
+        every { androidBuddyPluginConfiguration.getExcludePrefixes() }.returns(excludePrefixes)
 
         val result = byteBuddyTransform.parameterInputs
 
-        Truth.assertThat(result).containsExactly("librariesScopeHash", hash)
+        Truth.assertThat(result).containsExactly(
+            "librariesScopeHash", librariesScopeHash,
+            "transformationScopeHash", transformationScopeHash,
+            "excludePrefixesScopeHash", excludePrefixesHash
+        )
     }
 
     @Test
@@ -184,7 +198,11 @@ class ByteBuddyTransformTest : BaseMockable() {
         val allFiles = folders + jarFiles
         val outputFolder = mockk<File>()
         val filesHolder = mockk<FilesHolder>()
-        val transformScopes = mutableSetOf(QualifiedContent.Scope.PROJECT, QualifiedContent.Scope.SUB_PROJECTS, QualifiedContent.Scope.EXTERNAL_LIBRARIES)
+        val transformScopes = mutableSetOf(
+            QualifiedContent.Scope.PROJECT,
+            QualifiedContent.Scope.SUB_PROJECTS,
+            QualifiedContent.Scope.EXTERNAL_LIBRARIES
+        )
         val classFileLocator = mockk<ClassFileLocator>()
         val compoundSource = mockk<CompoundSource>()
         val jarOrigin1 = mockk<Plugin.Engine.Source.Origin.ForJarFile>()
@@ -214,9 +232,9 @@ class ByteBuddyTransformTest : BaseMockable() {
         every { filesHolder.allFiles }.returns(allFiles)
         every { classFileLocatorMaker.make(extraClasspath) }.returns(classFileLocator)
         every { sourceOriginForMultipleFoldersFactory.create(folders) }.returns(foldersOrigin)
-        every { jarOrigin1.iterator()}.returns(originIterator)
-        every { jarOrigin2.iterator()}.returns(originIterator)
-        every { originIterator.hasNext()}.returns(true)
+        every { jarOrigin1.iterator() }.returns(originIterator)
+        every { jarOrigin2.iterator() }.returns(originIterator)
+        every { originIterator.hasNext() }.returns(true)
         every { byteBuddyClassesInstantiator.makeJarFileSourceOrigin(jarFile1) }.returns(jarOrigin1)
         every { byteBuddyClassesInstantiator.makeJarFileSourceOrigin(jarFile2) }.returns(jarOrigin2)
         every {

--- a/android-buddy-plugin/src/test/java/com/likethesalad/android/buddy/modules/transform/ByteBuddyTransformTest.kt
+++ b/android-buddy-plugin/src/test/java/com/likethesalad/android/buddy/modules/transform/ByteBuddyTransformTest.kt
@@ -15,6 +15,8 @@ import com.likethesalad.android.buddy.configuration.libraries.scope.LibrariesSco
 import com.likethesalad.android.buddy.modules.transform.utils.PluginFactoriesProvider
 import com.likethesalad.android.buddy.modules.transform.utils.bytebuddy.SourceElementTransformationSkipPolicy
 import com.likethesalad.android.buddy.modules.transform.utils.bytebuddy.SourceElementTransformationSkipPolicyFactory
+import com.likethesalad.android.buddy.modules.transform.utils.bytebuddy.SourceElementTransformationSkippedStrategy
+import com.likethesalad.android.buddy.modules.transform.utils.bytebuddy.SourceElementTransformationSkippedStrategyFactory
 import com.likethesalad.android.buddy.providers.impl.DefaultLibrariesJarsProvider
 import com.likethesalad.android.buddy.providers.impl.DefaultLibrariesJarsProviderFactory
 import com.likethesalad.android.buddy.utils.ClassLoaderCreator
@@ -98,6 +100,12 @@ class ByteBuddyTransformTest : BaseMockable() {
     @MockK
     lateinit var sourceElementTransformationSkipPolicy: SourceElementTransformationSkipPolicy
 
+    @MockK
+    lateinit var sourceElementTransformationSkippedStrategyFactory: SourceElementTransformationSkippedStrategyFactory
+
+    @MockK
+    lateinit var sourceElementTransformationSkippedStrategy: SourceElementTransformationSkippedStrategy
+
     private val variantName = "someName"
     private val javaTargetVersion = 8
     private val excludePrefixes = setOf("prefix1", "prefix2")
@@ -140,7 +148,8 @@ class ByteBuddyTransformTest : BaseMockable() {
             androidExtensionDataProvider,
             defaultLibrariesJarsProviderFactory,
             androidBuddyPluginConfiguration,
-            sourceElementTransformationSkipPolicyFactory
+            sourceElementTransformationSkipPolicyFactory,
+            sourceElementTransformationSkippedStrategyFactory
         )
     }
 
@@ -240,6 +249,9 @@ class ByteBuddyTransformTest : BaseMockable() {
         every {
             transformInvocationDataExtractor.getOutputFolder(transformScopes)
         }.returns(outputFolder)
+        every {
+            sourceElementTransformationSkippedStrategyFactory.create(outputFolder)
+        }.returns(sourceElementTransformationSkippedStrategy)
         every { filesHolder.dirFiles }.returns(folders)
         every { filesHolder.jarFiles }.returns(jarFiles)
         every { filesHolder.allFiles }.returns(allFiles)
@@ -252,7 +264,8 @@ class ByteBuddyTransformTest : BaseMockable() {
         every { byteBuddyClassesInstantiator.makeJarFileSourceOrigin(jarFile2) }.returns(jarOrigin2)
         every {
             compoundSourceFactory.create(
-                setOf(foldersOrigin, jarOrigin1, jarOrigin2), sourceElementTransformationSkipPolicy
+                setOf(foldersOrigin, jarOrigin1, jarOrigin2),
+                sourceElementTransformationSkipPolicy, sourceElementTransformationSkippedStrategy
             )
         }.returns(compoundSource)
         every { byteBuddyClassesInstantiator.makeTargetForFolder(outputFolder) }.returns(target)

--- a/android-buddy-plugin/src/test/java/com/likethesalad/android/buddy/modules/transform/utils/FilePathScannerTest.kt
+++ b/android-buddy-plugin/src/test/java/com/likethesalad/android/buddy/modules/transform/utils/FilePathScannerTest.kt
@@ -1,0 +1,29 @@
+package com.likethesalad.android.buddy.modules.transform.utils
+
+import com.google.common.truth.Truth
+import org.junit.Test
+
+class FilePathScannerTest {
+
+    private val filePathScanner = FilePathScanner()
+
+    @Test
+    fun `Get file info from absolute path`() {
+        val path = "/home/user/file.txt"
+
+        val info = filePathScanner.scanFilePath(path)
+
+        Truth.assertThat(info.name).isEqualTo("file.txt")
+        Truth.assertThat(info.dirPath).isEqualTo("/home/user")
+    }
+
+    @Test
+    fun `Get file info from relative path`() {
+        val path = "androidx/activity/ktx/R\$drawable.class"
+
+        val info = filePathScanner.scanFilePath(path)
+
+        Truth.assertThat(info.name).isEqualTo("R\$drawable.class")
+        Truth.assertThat(info.dirPath).isEqualTo("androidx/activity/ktx")
+    }
+}

--- a/android-buddy-plugin/src/test/java/com/likethesalad/android/buddy/modules/transform/utils/bytebuddy/SourceElementTransformationSkipPolicyTest.kt
+++ b/android-buddy-plugin/src/test/java/com/likethesalad/android/buddy/modules/transform/utils/bytebuddy/SourceElementTransformationSkipPolicyTest.kt
@@ -1,0 +1,33 @@
+package com.likethesalad.android.buddy.modules.transform.utils.bytebuddy
+
+import com.google.common.truth.Truth
+import com.likethesalad.android.testutils.MockUtils.createSourceElementMock
+import org.junit.Test
+
+class SourceElementTransformationSkipPolicyTest {
+
+    @Test
+    fun `Don't skip items if there's no exclude prefixes`() {
+        verifyItemSkip("itemName", false)
+        verifyItemSkip("anotherItem", false)
+    }
+
+    @Test
+    fun `Skip items which names start with an excluded prefix`() {
+        val excludedPrefixes = setOf("itemName/something", "other/itemType/more")
+        verifyItemSkip("itemName/something/else", true, excludedPrefixes)
+        verifyItemSkip("other/itemType/else/something.class", false, excludedPrefixes)
+        verifyItemSkip("other/itemType/more/something.class", true, excludedPrefixes)
+    }
+
+    private fun verifyItemSkip(
+        itemName: String, shouldBeSkipped: Boolean,
+        excludedPrefixes: Set<String> = emptySet()
+    ) {
+        val item = createSourceElementMock(itemName)
+        val instance = SourceElementTransformationSkipPolicy(excludedPrefixes)
+        val shouldSkip = instance.shouldSkipItem(item)
+
+        Truth.assertThat(shouldSkip).isEqualTo(shouldBeSkipped)
+    }
+}

--- a/android-buddy-plugin/src/test/java/com/likethesalad/android/buddy/modules/transform/utils/bytebuddy/SourceElementTransformationSkippedStrategyTest.kt
+++ b/android-buddy-plugin/src/test/java/com/likethesalad/android/buddy/modules/transform/utils/bytebuddy/SourceElementTransformationSkippedStrategyTest.kt
@@ -2,16 +2,25 @@ package com.likethesalad.android.buddy.modules.transform.utils.bytebuddy
 
 import com.google.common.truth.Truth
 import com.likethesalad.android.buddy.modules.transform.utils.FilePathScanner
+import com.likethesalad.android.common.utils.Logger
+import com.likethesalad.android.testutils.BaseMockable
 import com.likethesalad.android.testutils.DummyResourcesFinder
 import com.likethesalad.android.testutils.MockUtils.createSourceElementMock
+import io.mockk.Runs
 import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.just
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import java.io.File
+import java.io.InputStream
 
-class SourceElementTransformationSkippedStrategyTest {
+class SourceElementTransformationSkippedStrategyTest : BaseMockable() {
+
+    @MockK
+    lateinit var logger: Logger
 
     @get:Rule
     val temporaryFolder = TemporaryFolder()
@@ -27,13 +36,14 @@ class SourceElementTransformationSkippedStrategyTest {
     @Before
     fun setUp() {
         outputDir = temporaryFolder.newFolder(outputFileName)
+        every { logger.debug(any(), any()) } just Runs
 
         sourceElementTransformationSkippedStrategy =
-            SourceElementTransformationSkippedStrategy(outputDir, filePathScanner)
+            SourceElementTransformationSkippedStrategy(outputDir, filePathScanner, logger)
     }
 
     @Test
-    fun `Save item into output dir`() {
+    fun `Save file item into output dir`() {
         val relativeOutputPath = "some/path/to/file.txt"
         val item = createSourceElementMock(relativeOutputPath)
         val localFile = getLocalFile()
@@ -47,6 +57,20 @@ class SourceElementTransformationSkippedStrategyTest {
         val expectedFile = File(outputDir, relativeOutputPath)
         Truth.assertThat(expectedFile.exists()).isTrue()
         Truth.assertThat(expectedFile.readText()).isEqualTo(localFile.readText())
+    }
+
+    @Test
+    fun `Ignore folder item into output dir`() {
+        val relativeOutputPath = "some/path/to/dir"
+        val outputFile = File(outputDir, relativeOutputPath)
+        val item = createSourceElementMock(relativeOutputPath)
+        val localInputStream = mockk<InputStream>()
+        every { localInputStream.available() }.returns(0)
+        every { item.inputStream }.returns(localInputStream)
+
+        sourceElementTransformationSkippedStrategy.onTransformationSkipped(item)
+
+        Truth.assertThat(outputFile.exists()).isFalse()
     }
 
     private fun getLocalFile(): File {

--- a/android-buddy-plugin/src/test/java/com/likethesalad/android/buddy/modules/transform/utils/bytebuddy/SourceElementTransformationSkippedStrategyTest.kt
+++ b/android-buddy-plugin/src/test/java/com/likethesalad/android/buddy/modules/transform/utils/bytebuddy/SourceElementTransformationSkippedStrategyTest.kt
@@ -1,0 +1,56 @@
+package com.likethesalad.android.buddy.modules.transform.utils.bytebuddy
+
+import com.google.common.truth.Truth
+import com.likethesalad.android.buddy.modules.transform.utils.FilePathScanner
+import com.likethesalad.android.testutils.DummyResourcesFinder
+import com.likethesalad.android.testutils.MockUtils.createSourceElementMock
+import io.mockk.every
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class SourceElementTransformationSkippedStrategyTest {
+
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    private val dummyResourcesFinder = DummyResourcesFinder()
+
+    private val filePathScanner = FilePathScanner()
+    private val outputFileName = "main"
+    private lateinit var outputDir: File
+
+    private lateinit var sourceElementTransformationSkippedStrategy: SourceElementTransformationSkippedStrategy
+
+    @Before
+    fun setUp() {
+        outputDir = temporaryFolder.newFolder(outputFileName)
+
+        sourceElementTransformationSkippedStrategy =
+            SourceElementTransformationSkippedStrategy(outputDir, filePathScanner)
+    }
+
+    @Test
+    fun `Save item into output dir`() {
+        val relativeOutputPath = "some/path/to/file.txt"
+        val item = createSourceElementMock(relativeOutputPath)
+        val localFile = getLocalFile()
+        val localInputStream = localFile.inputStream()
+        every { item.inputStream }.returns(localInputStream)
+
+        localInputStream.use {
+            sourceElementTransformationSkippedStrategy.onTransformationSkipped(item)
+        }
+
+        val expectedFile = File(outputDir, relativeOutputPath)
+        Truth.assertThat(expectedFile.exists()).isTrue()
+        Truth.assertThat(expectedFile.readText()).isEqualTo(localFile.readText())
+    }
+
+    private fun getLocalFile(): File {
+        return dummyResourcesFinder
+            .getResourceFile("classdirs/withplugins/com/likethesalad/android/buddy/AndroidBuddyPlugin.class")
+    }
+}

--- a/android-buddy-plugin/src/test/java/com/likethesalad/android/buddy/utils/SourceElementsIteratorTest.kt
+++ b/android-buddy-plugin/src/test/java/com/likethesalad/android/buddy/utils/SourceElementsIteratorTest.kt
@@ -1,0 +1,56 @@
+package com.likethesalad.android.buddy.utils
+
+import com.google.common.truth.Truth
+import com.likethesalad.android.testutils.BaseMockable
+import com.likethesalad.android.testutils.MockUtils.createSourceElementMock
+import net.bytebuddy.build.Plugin
+import org.junit.Test
+
+class SourceElementsIteratorTest : BaseMockable() {
+
+    @Test
+    fun `Iterate through all items`() {
+        val items1 = createIteratorOfSourceElementsWithNames("item1_1", "item1_2")
+        val items2 = createIteratorOfSourceElementsWithNames("item2_1", "item2_2")
+        val list = mutableListOf(items1, items2)
+
+        val iterator = createSourceElementsIterator(list)
+
+        Truth.assertThat(getItemNamesFromIterator(iterator))
+            .containsExactly("item1_1", "item1_2", "item2_1", "item2_2")
+    }
+
+    @Test
+    fun `Ignore empty iterators and keep going further on the list`() {
+        val items1 = createIteratorOfSourceElementsWithNames("item1_1", "item1_2")
+        val items2 = createIteratorOfSourceElementsWithNames()
+        val items3 = createIteratorOfSourceElementsWithNames("item3_1", "item3_2")
+        val list = mutableListOf(items1, items2, items3)
+
+        val iterator = createSourceElementsIterator(list)
+
+        Truth.assertThat(getItemNamesFromIterator(iterator))
+            .containsExactly("item1_1", "item1_2", "item3_1", "item3_2")
+    }
+
+    private fun getItemNamesFromIterator(iterator: SourceElementsIterator): List<String> {
+        val names = mutableListOf<String>()
+        while (iterator.hasNext()) {
+            names.add(iterator.next().name)
+        }
+
+        return names
+    }
+
+    private fun createSourceElementsIterator(
+        iterators: MutableList<out Iterator<Plugin.Engine.Source.Element>>,
+        excludePrefixes: Set<String> = emptySet()
+    ): SourceElementsIterator {
+        return SourceElementsIterator(iterators, excludePrefixes)
+    }
+
+    private fun createIteratorOfSourceElementsWithNames(vararg names: String): Iterator<Plugin.Engine.Source.Element> {
+        val list = names.map { createSourceElementMock(it) }
+        return list.iterator()
+    }
+}

--- a/android-buddy-plugin/src/test/java/com/likethesalad/android/buddy/utils/SourceElementsIteratorTest.kt
+++ b/android-buddy-plugin/src/test/java/com/likethesalad/android/buddy/utils/SourceElementsIteratorTest.kt
@@ -2,10 +2,12 @@ package com.likethesalad.android.buddy.utils
 
 import com.google.common.truth.Truth
 import com.likethesalad.android.buddy.modules.transform.utils.bytebuddy.SourceElementTransformationSkipPolicy
+import com.likethesalad.android.buddy.modules.transform.utils.bytebuddy.SourceElementTransformationSkippedStrategy
 import com.likethesalad.android.testutils.BaseMockable
 import com.likethesalad.android.testutils.MockUtils.createSourceElementMock
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
+import io.mockk.verify
 import net.bytebuddy.build.Plugin
 import org.junit.Before
 import org.junit.Test
@@ -14,6 +16,9 @@ class SourceElementsIteratorTest : BaseMockable() {
 
     @MockK
     lateinit var skipPolicy: SourceElementTransformationSkipPolicy
+
+    @MockK
+    lateinit var skippedStrategy: SourceElementTransformationSkippedStrategy
 
     @Before
     fun setUp() {
@@ -61,6 +66,10 @@ class SourceElementsIteratorTest : BaseMockable() {
 
         Truth.assertThat(getItemNamesFromIterator(iterator))
             .containsExactly("item1_1", "item3_2", "item4_1")
+        verify {
+            skippedStrategy.onTransformationSkipped(skipItem1_2)
+            skippedStrategy.onTransformationSkipped(skipItem3_1)
+        }
     }
 
     private fun getItemNamesFromIterator(iterator: SourceElementsIterator): List<String> {
@@ -75,7 +84,7 @@ class SourceElementsIteratorTest : BaseMockable() {
     private fun createSourceElementsIterator(
         iterators: MutableList<out Iterator<Plugin.Engine.Source.Element>>
     ): SourceElementsIterator {
-        return SourceElementsIterator(iterators, skipPolicy)
+        return SourceElementsIterator(iterators, skipPolicy, skippedStrategy)
     }
 
     private fun createIteratorOfSourceElementsWithNames(vararg names: String): Iterator<Plugin.Engine.Source.Element> {

--- a/android-buddy-plugin/src/test/java/com/likethesalad/android/buddy/utils/SourceElementsIteratorTest.kt
+++ b/android-buddy-plugin/src/test/java/com/likethesalad/android/buddy/utils/SourceElementsIteratorTest.kt
@@ -1,12 +1,24 @@
 package com.likethesalad.android.buddy.utils
 
 import com.google.common.truth.Truth
+import com.likethesalad.android.buddy.modules.transform.utils.bytebuddy.SourceElementTransformationSkipPolicy
 import com.likethesalad.android.testutils.BaseMockable
 import com.likethesalad.android.testutils.MockUtils.createSourceElementMock
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
 import net.bytebuddy.build.Plugin
+import org.junit.Before
 import org.junit.Test
 
 class SourceElementsIteratorTest : BaseMockable() {
+
+    @MockK
+    lateinit var skipPolicy: SourceElementTransformationSkipPolicy
+
+    @Before
+    fun setUp() {
+        every { skipPolicy.shouldSkipItem(any()) }.returns(false)
+    }
 
     @Test
     fun `Iterate through all items`() {
@@ -33,6 +45,24 @@ class SourceElementsIteratorTest : BaseMockable() {
             .containsExactly("item1_1", "item1_2", "item3_1", "item3_2")
     }
 
+    @Test
+    fun `Skip items that require to be skipped`() {
+        val skipItem1_2 = createSourceElementMock("item1_2")
+        val skipItem3_1 = createSourceElementMock("item3_1")
+        val items1 = createIteratorOfSourceElements(createSourceElementMock("item1_1"), skipItem1_2)
+        val items2 = createIteratorOfSourceElementsWithNames()
+        val items3 = createIteratorOfSourceElements(skipItem3_1, createSourceElementMock("item3_2"))
+        val items4 = createIteratorOfSourceElementsWithNames("item4_1")
+        val list = mutableListOf(items1, items2, items3, items4)
+        every { skipPolicy.shouldSkipItem(skipItem1_2) }.returns(true)
+        every { skipPolicy.shouldSkipItem(skipItem3_1) }.returns(true)
+
+        val iterator = createSourceElementsIterator(list)
+
+        Truth.assertThat(getItemNamesFromIterator(iterator))
+            .containsExactly("item1_1", "item3_2", "item4_1")
+    }
+
     private fun getItemNamesFromIterator(iterator: SourceElementsIterator): List<String> {
         val names = mutableListOf<String>()
         while (iterator.hasNext()) {
@@ -43,14 +73,18 @@ class SourceElementsIteratorTest : BaseMockable() {
     }
 
     private fun createSourceElementsIterator(
-        iterators: MutableList<out Iterator<Plugin.Engine.Source.Element>>,
-        excludePrefixes: Set<String> = emptySet()
+        iterators: MutableList<out Iterator<Plugin.Engine.Source.Element>>
     ): SourceElementsIterator {
-        return SourceElementsIterator(iterators, excludePrefixes)
+        return SourceElementsIterator(iterators, skipPolicy)
     }
 
     private fun createIteratorOfSourceElementsWithNames(vararg names: String): Iterator<Plugin.Engine.Source.Element> {
         val list = names.map { createSourceElementMock(it) }
-        return list.iterator()
+        return createIteratorOfSourceElements(*list.toTypedArray())
+    }
+
+    private fun createIteratorOfSourceElements(vararg items: Plugin.Engine.Source.Element)
+            : Iterator<Plugin.Engine.Source.Element> {
+        return items.iterator()
     }
 }

--- a/android-buddy-plugin/src/test/java/com/likethesalad/android/testutils/MockUtils.kt
+++ b/android-buddy-plugin/src/test/java/com/likethesalad/android/testutils/MockUtils.kt
@@ -1,0 +1,15 @@
+package com.likethesalad.android.testutils
+
+import io.mockk.every
+import io.mockk.mockk
+import net.bytebuddy.build.Plugin
+
+object MockUtils {
+
+    fun createSourceElementMock(name: String): Plugin.Engine.Source.Element {
+        val mock = mockk<Plugin.Engine.Source.Element>()
+        every { mock.name }.returns(name)
+
+        return mock
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ ext {
 }
 
 group 'com.likethesalad.android'
-version '1.1.0'
+version '1.1.1'
 
 subprojects {
     repositories {


### PR DESCRIPTION
Saving classes that were skipped from transformation into the final runtime classpath.

We need all of the classes in the final runtime classpath, and before this change, we were letting the ones skipped by the "excludePrefix" config out of the runtime classpath which was causing runtime crashes due to not found classes.